### PR TITLE
Fix ET_Client::__construct incorrectly checking the response object

### DIFF
--- a/ET_Client.php
+++ b/ET_Client.php
@@ -58,7 +58,7 @@ class ET_Client extends SoapClient {
 			$url = "https://www.exacttargetapis.com/platform/v1/endpoints/soap?access_token=".$this->getAuthToken($this->tenantKey);
 			$endpointResponse = restGet($url);			
 			$endpointObject = json_decode($endpointResponse->body);			
-			if ($endpointResponse && property_exists($endpointObject,"url")){		
+			if ($endpointObject && property_exists($endpointObject,"url")){
 				$this->endpoint = $endpointObject->url;			
 			} else {
 				throw new Exception('Unable to determine stack using /platform/v1/endpoints/:'.$endpointResponse->body);			


### PR DESCRIPTION
Fix ET_Client::__construct incorrectly checking the response object instead of the response body for an endpoint URL